### PR TITLE
Fix Android boot, widget, and reconnect flows

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -434,8 +434,8 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.9.7")
 
     // Hilt
-    implementation("com.google.dagger:hilt-android:2.59.1")
-    kapt("com.google.dagger:hilt-compiler:2.59.1")
+    implementation("com.google.dagger:hilt-android:2.57.1")
+    kapt("com.google.dagger:hilt-compiler:2.57.1")
     implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
 
     // Room

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
 
     <application
         android:name=".SlipNetApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -98,11 +98,9 @@
         <!-- Boot Receiver -->
         <receiver
             android:name=".service.BootReceiver"
-            android:exported="true"
-            android:directBootAware="true">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 
@@ -112,7 +110,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-                <action android:name="app.slipnet.widget.TOGGLE_VPN" />
             </intent-filter>
             <meta-data
                 android:name="android.appwidget.provider"
@@ -125,12 +122,15 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-                <action android:name="app.slipnet.widget.TOGGLE_VPN_COMPACT" />
             </intent-filter>
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/widget_vpn_compact_info" />
         </receiver>
+
+        <receiver
+            android:name=".widget.VpnWidgetToggleReceiver"
+            android:exported="false" />
 
         <!-- QR code scanner (force portrait) -->
         <activity

--- a/app/src/main/java/app/slipnet/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/app/slipnet/presentation/main/MainViewModel.kt
@@ -270,12 +270,12 @@ class MainViewModel @Inject constructor(
             val lastCheck = preferencesDataStore.lastUpdateCheckTime.first()
             val now = System.currentTimeMillis()
             if (now - lastCheck < app.slipnet.util.UpdateChecker.CHECK_INTERVAL_MS) return@launch
+            preferencesDataStore.setLastUpdateCheckTime(now)
 
             val skipped = preferencesDataStore.skippedUpdateVersion.first()
             val current = app.slipnet.BuildConfig.VERSION_NAME
 
             val update = app.slipnet.util.UpdateChecker.check(current) ?: return@launch
-            preferencesDataStore.setLastUpdateCheckTime(now)
 
             // Don't show if user already skipped this version
             if (update.versionName == skipped) return@launch

--- a/app/src/main/java/app/slipnet/service/BootReceiver.kt
+++ b/app/src/main/java/app/slipnet/service/BootReceiver.kt
@@ -6,16 +6,22 @@ import android.content.Intent
 import android.net.VpnService
 import app.slipnet.data.local.datastore.PreferencesDataStore
 import app.slipnet.domain.repository.ProfileRepository
+import app.slipnet.util.AppLog as Log
 import dagger.hilt.android.AndroidEntryPoint
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class BootReceiver : BroadcastReceiver() {
+
+    companion object {
+        private const val TAG = "BootReceiver"
+    }
 
     @Inject
     lateinit var preferencesDataStore: PreferencesDataStore
@@ -26,38 +32,46 @@ class BootReceiver : BroadcastReceiver() {
     @Inject
     lateinit var connectionManager: VpnConnectionManager
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != Intent.ACTION_BOOT_COMPLETED &&
-            intent.action != Intent.ACTION_LOCKED_BOOT_COMPLETED) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) {
             return
         }
 
+        val pendingResult = goAsync()
+        val appContext = context.applicationContext
+
         scope.launch {
-            val autoConnect = preferencesDataStore.autoConnectOnBoot.first()
-            if (!autoConnect) {
-                return@launch
-            }
+            try {
+                val autoConnect = preferencesDataStore.autoConnectOnBoot.first()
+                if (!autoConnect) {
+                    return@launch
+                }
 
-            // Get active or last connected profile
-            val profile = profileRepository.getActiveProfile().first()
-                ?: getLastConnectedProfile()
-                ?: return@launch
+                // Get active or last connected profile
+                val profile = profileRepository.getActiveProfile().first()
+                    ?: getLastConnectedProfile()
+                    ?: return@launch
 
-            // Check if we have VPN permission (must have been granted before)
-            val vpnIntent = VpnService.prepare(context)
-            if (vpnIntent != null) {
-                // VPN permission not granted, can't auto-connect
-                return@launch
-            }
+                // Check if we have VPN permission (must have been granted before)
+                val vpnIntent = VpnService.prepare(appContext)
+                if (vpnIntent != null) {
+                    // VPN permission not granted, can't auto-connect
+                    return@launch
+                }
 
-            // Start VPN service
-            val serviceIntent = Intent(context, SlipNetVpnService::class.java).apply {
-                action = SlipNetVpnService.ACTION_CONNECT
-                putExtra(SlipNetVpnService.EXTRA_PROFILE_ID, profile.id)
+                // Start VPN service
+                val serviceIntent = Intent(appContext, SlipNetVpnService::class.java).apply {
+                    action = SlipNetVpnService.ACTION_CONNECT
+                    putExtra(SlipNetVpnService.EXTRA_PROFILE_ID, profile.id)
+                }
+                ContextCompat.startForegroundService(appContext, serviceIntent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to auto-connect on boot", e)
+            } finally {
+                pendingResult.finish()
             }
-            context.startForegroundService(serviceIntent)
         }
     }
 

--- a/app/src/main/java/app/slipnet/service/NotificationHelper.kt
+++ b/app/src/main/java/app/slipnet/service/NotificationHelper.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.core.app.NotificationCompat
 import app.slipnet.R
 import app.slipnet.SlipNetApp
@@ -29,6 +30,19 @@ class NotificationHelper @Inject constructor(
         const val AUTO_RECONNECT_NOTIFICATION_ID = 4
         const val PROBE_FAIL_NOTIFICATION_ID = 5
         private const val REQUEST_CODE_PROBE_RECONNECT = 105
+    }
+
+    private fun createServicePendingIntent(
+        requestCode: Int,
+        intent: Intent,
+        foreground: Boolean = false
+    ): PendingIntent {
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        return if (foreground && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PendingIntent.getForegroundService(context, requestCode, intent, flags)
+        } else {
+            PendingIntent.getService(context, requestCode, intent, flags)
+        }
     }
 
     fun createVpnNotification(
@@ -69,11 +83,9 @@ class NotificationHelper @Inject constructor(
                 val disconnectIntent = Intent(context, SlipNetVpnService::class.java).apply {
                     action = SlipNetVpnService.ACTION_DISCONNECT
                 }
-                val disconnectPendingIntent = PendingIntent.getService(
-                    context,
-                    REQUEST_CODE_DISCONNECT,
-                    disconnectIntent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                val disconnectPendingIntent = createServicePendingIntent(
+                    requestCode = REQUEST_CODE_DISCONNECT,
+                    intent = disconnectIntent
                 )
 
                 builder
@@ -115,11 +127,9 @@ class NotificationHelper @Inject constructor(
         val disconnectIntent = Intent(context, SlipNetVpnService::class.java).apply {
             action = SlipNetVpnService.ACTION_DISCONNECT
         }
-        val disconnectPendingIntent = PendingIntent.getService(
-            context,
-            REQUEST_CODE_DISCONNECT,
-            disconnectIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val disconnectPendingIntent = createServicePendingIntent(
+            requestCode = REQUEST_CODE_DISCONNECT,
+            intent = disconnectIntent
         )
 
         return NotificationCompat.Builder(context, SlipNetApp.CHANNEL_VPN_STATUS)
@@ -153,11 +163,9 @@ class NotificationHelper @Inject constructor(
         val disconnectIntent = Intent(context, SlipNetVpnService::class.java).apply {
             action = SlipNetVpnService.ACTION_DISCONNECT
         }
-        val disconnectPendingIntent = PendingIntent.getService(
-            context,
-            REQUEST_CODE_AUTO_RECONNECT_CANCEL,
-            disconnectIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val disconnectPendingIntent = createServicePendingIntent(
+            requestCode = REQUEST_CODE_AUTO_RECONNECT_CANCEL,
+            intent = disconnectIntent
         )
 
         return NotificationCompat.Builder(context, SlipNetApp.CHANNEL_VPN_STATUS)
@@ -191,11 +199,10 @@ class NotificationHelper @Inject constructor(
             action = SlipNetVpnService.ACTION_CONNECT
             putExtra(SlipNetVpnService.EXTRA_PROFILE_ID, profileId)
         }
-        val reconnectPendingIntent = PendingIntent.getService(
-            context,
-            REQUEST_CODE_RECONNECT,
-            reconnectIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val reconnectPendingIntent = createServicePendingIntent(
+            requestCode = REQUEST_CODE_RECONNECT,
+            intent = reconnectIntent,
+            foreground = true
         )
 
         return NotificationCompat.Builder(context, SlipNetApp.CHANNEL_CONNECTION_EVENTS)
@@ -255,11 +262,10 @@ class NotificationHelper @Inject constructor(
             action = SlipNetVpnService.ACTION_CONNECT
             putExtra(SlipNetVpnService.EXTRA_PROFILE_ID, profileId)
         }
-        val reconnectPendingIntent = PendingIntent.getService(
-            context,
-            REQUEST_CODE_RECONNECT_DISCONNECT,
-            reconnectIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val reconnectPendingIntent = createServicePendingIntent(
+            requestCode = REQUEST_CODE_RECONNECT_DISCONNECT,
+            intent = reconnectIntent,
+            foreground = true
         )
 
         return NotificationCompat.Builder(context, SlipNetApp.CHANNEL_CONNECTION_EVENTS)
@@ -288,11 +294,10 @@ class NotificationHelper @Inject constructor(
             action = SlipNetVpnService.ACTION_CONNECT
             putExtra(SlipNetVpnService.EXTRA_PROFILE_ID, profileId)
         }
-        val reconnectPendingIntent = PendingIntent.getService(
-            context,
-            REQUEST_CODE_PROBE_RECONNECT,
-            reconnectIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val reconnectPendingIntent = createServicePendingIntent(
+            requestCode = REQUEST_CODE_PROBE_RECONNECT,
+            intent = reconnectIntent,
+            foreground = true
         )
 
         return NotificationCompat.Builder(context, SlipNetApp.CHANNEL_CONNECTION_EVENTS)

--- a/app/src/main/java/app/slipnet/service/VpnConnectionManager.kt
+++ b/app/src/main/java/app/slipnet/service/VpnConnectionManager.kt
@@ -11,6 +11,7 @@ import app.slipnet.domain.repository.ProfileRepository
 import app.slipnet.widget.VpnWidgetCompactProvider
 import app.slipnet.widget.VpnWidgetProvider
 import app.slipnet.util.DeviceIdUtil
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -88,7 +89,7 @@ class VpnConnectionManager @Inject constructor(
             action = SlipNetVpnService.ACTION_CONNECT
             putExtra(SlipNetVpnService.EXTRA_PROFILE_ID, profile.id)
         }
-        context.startForegroundService(intent)
+        ContextCompat.startForegroundService(context, intent)
     }
 
     fun reconnect(profile: ServerProfile) {
@@ -114,7 +115,7 @@ class VpnConnectionManager @Inject constructor(
             action = SlipNetVpnService.ACTION_CONNECT
             putExtra(SlipNetVpnService.EXTRA_PROFILE_ID, profile.id)
         }
-        context.startForegroundService(intent)
+        ContextCompat.startForegroundService(context, intent)
     }
 
     fun disconnect() {

--- a/app/src/main/java/app/slipnet/widget/VpnWidgetCompactProvider.kt
+++ b/app/src/main/java/app/slipnet/widget/VpnWidgetCompactProvider.kt
@@ -6,18 +6,12 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.net.VpnService
 import android.view.View
 import android.widget.RemoteViews
 import app.slipnet.R
 import app.slipnet.domain.model.ConnectionState
-import app.slipnet.presentation.MainActivity
 import app.slipnet.service.VpnConnectionManager
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,8 +19,6 @@ class VpnWidgetCompactProvider : AppWidgetProvider() {
 
     @Inject
     lateinit var connectionManager: VpnConnectionManager
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     override fun onUpdate(
         context: Context,
@@ -45,52 +37,7 @@ class VpnWidgetCompactProvider : AppWidgetProvider() {
         }
     }
 
-    override fun onReceive(context: Context, intent: Intent) {
-        super.onReceive(context, intent)
-
-        if (intent.action == ACTION_TOGGLE_VPN_COMPACT) {
-            handleToggle(context)
-        }
-    }
-
-    private fun handleToggle(context: Context) {
-        if (!::connectionManager.isInitialized) return
-
-        scope.launch {
-            val currentState = connectionManager.connectionState.value
-
-            when (currentState) {
-                is ConnectionState.Connected,
-                is ConnectionState.Connecting -> {
-                    connectionManager.disconnect()
-                }
-                is ConnectionState.Disconnected,
-                is ConnectionState.Error -> {
-                    val profile = connectionManager.getActiveProfile()
-                        ?: connectionManager.getLastConnectedProfile()
-                        ?: return@launch
-
-                    val vpnIntent = VpnService.prepare(context)
-                    if (vpnIntent != null) {
-                        val appIntent = Intent(context, MainActivity::class.java).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        }
-                        context.startActivity(appIntent)
-                        return@launch
-                    }
-
-                    connectionManager.connect(profile)
-                }
-                is ConnectionState.Disconnecting -> {
-                    // Wait for disconnect to complete
-                }
-            }
-        }
-    }
-
     companion object {
-        const val ACTION_TOGGLE_VPN_COMPACT = "app.slipnet.widget.TOGGLE_VPN_COMPACT"
-
         fun notifyStateChanged(context: Context, state: ConnectionState) {
             val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
             val componentName = ComponentName(context, VpnWidgetCompactProvider::class.java)
@@ -108,8 +55,8 @@ class VpnWidgetCompactProvider : AppWidgetProvider() {
             val views = RemoteViews(context.packageName, R.layout.widget_vpn_compact)
 
             // Set tap action
-            val toggleIntent = Intent(context, VpnWidgetCompactProvider::class.java).apply {
-                action = ACTION_TOGGLE_VPN_COMPACT
+            val toggleIntent = Intent(context, VpnWidgetToggleReceiver::class.java).apply {
+                action = VpnWidgetToggleReceiver.ACTION_TOGGLE_VPN
             }
             val pendingIntent = PendingIntent.getBroadcast(
                 context, 1, toggleIntent,

--- a/app/src/main/java/app/slipnet/widget/VpnWidgetProvider.kt
+++ b/app/src/main/java/app/slipnet/widget/VpnWidgetProvider.kt
@@ -6,18 +6,12 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.net.VpnService
 import android.view.View
 import android.widget.RemoteViews
 import app.slipnet.R
 import app.slipnet.domain.model.ConnectionState
-import app.slipnet.presentation.MainActivity
 import app.slipnet.service.VpnConnectionManager
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,8 +19,6 @@ class VpnWidgetProvider : AppWidgetProvider() {
 
     @Inject
     lateinit var connectionManager: VpnConnectionManager
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     override fun onUpdate(
         context: Context,
@@ -45,53 +37,7 @@ class VpnWidgetProvider : AppWidgetProvider() {
         }
     }
 
-    override fun onReceive(context: Context, intent: Intent) {
-        super.onReceive(context, intent)
-
-        if (intent.action == ACTION_TOGGLE_VPN) {
-            handleToggle(context)
-        }
-    }
-
-    private fun handleToggle(context: Context) {
-        if (!::connectionManager.isInitialized) return
-
-        scope.launch {
-            val currentState = connectionManager.connectionState.value
-
-            when (currentState) {
-                is ConnectionState.Connected,
-                is ConnectionState.Connecting -> {
-                    connectionManager.disconnect()
-                }
-                is ConnectionState.Disconnected,
-                is ConnectionState.Error -> {
-                    val profile = connectionManager.getActiveProfile()
-                        ?: connectionManager.getLastConnectedProfile()
-                        ?: return@launch
-
-                    val vpnIntent = VpnService.prepare(context)
-                    if (vpnIntent != null) {
-                        // Need VPN permission — open the app
-                        val appIntent = Intent(context, MainActivity::class.java).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        }
-                        context.startActivity(appIntent)
-                        return@launch
-                    }
-
-                    connectionManager.connect(profile)
-                }
-                is ConnectionState.Disconnecting -> {
-                    // Wait for disconnect to complete
-                }
-            }
-        }
-    }
-
     companion object {
-        const val ACTION_TOGGLE_VPN = "app.slipnet.widget.TOGGLE_VPN"
-
         fun notifyStateChanged(context: Context, state: ConnectionState) {
             val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
             val componentName = ComponentName(context, VpnWidgetProvider::class.java)
@@ -109,8 +55,8 @@ class VpnWidgetProvider : AppWidgetProvider() {
             val views = RemoteViews(context.packageName, R.layout.widget_vpn_toggle)
 
             // Set tap action
-            val toggleIntent = Intent(context, VpnWidgetProvider::class.java).apply {
-                action = ACTION_TOGGLE_VPN
+            val toggleIntent = Intent(context, VpnWidgetToggleReceiver::class.java).apply {
+                action = VpnWidgetToggleReceiver.ACTION_TOGGLE_VPN
             }
             val pendingIntent = PendingIntent.getBroadcast(
                 context, 0, toggleIntent,

--- a/app/src/main/java/app/slipnet/widget/VpnWidgetToggleReceiver.kt
+++ b/app/src/main/java/app/slipnet/widget/VpnWidgetToggleReceiver.kt
@@ -1,0 +1,76 @@
+package app.slipnet.widget
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.VpnService
+import app.slipnet.domain.model.ConnectionState
+import app.slipnet.presentation.MainActivity
+import app.slipnet.service.VpnConnectionManager
+import app.slipnet.util.AppLog as Log
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class VpnWidgetToggleReceiver : BroadcastReceiver() {
+
+    companion object {
+        private const val TAG = "VpnWidgetToggleReceiver"
+        const val ACTION_TOGGLE_VPN = "app.slipnet.widget.TOGGLE_VPN"
+    }
+
+    @Inject
+    lateinit var connectionManager: VpnConnectionManager
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_TOGGLE_VPN) {
+            return
+        }
+
+        val pendingResult = goAsync()
+        val appContext = context.applicationContext
+
+        scope.launch {
+            try {
+                if (!::connectionManager.isInitialized) {
+                    return@launch
+                }
+
+                when (connectionManager.connectionState.value) {
+                    is ConnectionState.Connected,
+                    is ConnectionState.Connecting -> {
+                        connectionManager.disconnect()
+                    }
+                    is ConnectionState.Disconnected,
+                    is ConnectionState.Error -> {
+                        val profile = connectionManager.getActiveProfile()
+                            ?: connectionManager.getLastConnectedProfile()
+                            ?: return@launch
+
+                        val vpnIntent = VpnService.prepare(appContext)
+                        if (vpnIntent != null) {
+                            val appIntent = Intent(appContext, MainActivity::class.java).apply {
+                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                            appContext.startActivity(appIntent)
+                            return@launch
+                        }
+
+                        connectionManager.connect(profile)
+                    }
+                    is ConnectionState.Disconnecting -> Unit
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to handle widget toggle", e)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move VPN widget toggling into a dedicated `VpnWidgetToggleReceiver` so widget providers only update UI and toggle handling runs through a single Hilt-enabled receiver
- harden boot and reconnect startup paths by using `goAsync()`, `ContextCompat.startForegroundService(...)`, and foreground-service pending intents where Android expects them
- avoid repeated update checks after failures by saving the last-check timestamp before the network request, disable app backups, and pin Hilt to `2.57.1` to match the current project setup

## Details
- `BootReceiver` now handles only `BOOT_COMPLETED`, uses the application context, logs failures, and finishes its async work explicitly
- both widget providers now route tap actions through `VpnWidgetToggleReceiver`, which reconnects/disconnects centrally and opens the app when VPN permission still needs user approval
- reconnect notification actions now create service intents with `PendingIntent.getForegroundService(...)` on Android O+ so reconnect actions start reliably from notifications

## Testing
- `./gradlew :app:compileFullDebugKotlin --console=plain --no-daemon`
- `./gradlew :app:compileLiteDebugKotlin --console=plain --no-daemon`