### PR TITLE
Fix E2E test SSH variant detection for NoizDNS_SSH profiles

### DIFF
--- a/app/src/main/java/app/slipnet/data/repository/ResolverScannerRepositoryImpl.kt
+++ b/app/src/main/java/app/slipnet/data/repository/ResolverScannerRepositoryImpl.kt
@@ -931,7 +931,7 @@ class ResolverScannerRepositoryImpl @Inject constructor(
                 )
             }
 
-            val isSshVariant = profile.tunnelType == TunnelType.DNSTT_SSH
+            val isSshVariant = profile.tunnelType == TunnelType.DNSTT_SSH || profile.tunnelType == TunnelType.NOIZDNS_SSH
 
             if (!isSshVariant) {
                 // Non-SSH: start DnsttSocksBridge (same as VPN flow) to handle


### PR DESCRIPTION
NoizDNS_SSH profiles were incorrectly taking the SOCKS/HTTP test path instead of the SSH handshake path because `isSshVariant` only checked for DNSTT_SSH.